### PR TITLE
Add new SSG Feature: Support --config with Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ node textToHTML -i <filename/foldername> -s <stylesheet url or path> -o <alterna
 node textToHTML --input <filename/foldername> --stylesheet <stylesheet url or path> --output <alternate folder output>
 
 node textToHTML --input <filename/foldername> --stylesheet <stylesheet url or path> 
+
+node textToHTML -c <config JSON filename>
 ```
 ### Features
 ```
 - Supports outputting to a specified folder.
 - Allows adding of custom stylesheets to generated HTML files.
 - If a Markdown file is provided, h1 and h2 headings may be generated using "#" and "##" respectively.
+- Read config file properties and uses them in place of command line arguments.
 ```
 ### Support
 ```

--- a/textToHTML.js
+++ b/textToHTML.js
@@ -28,6 +28,11 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
     describe: 'language for the HTML document.',
     type: 'string'
   }
+  ).option('c', {
+    alias: 'config',
+    demandOption: false,
+    describe: 'Accept a file path to a JSON config file.',
+  }
   ).alias('h', 'help')
   .alias('v', 'version')
   .alias('i', 'input')
@@ -55,6 +60,19 @@ if(argv.o === "./dist"){
       }
     });
 }
+//add config
+if(argv.c){
+  const configJson = fs.readFileSync(path.normalize(argv.c));
+  const con = JSON.parse(configJson);
+  argv.input = con.input;
+  argv.stylesheet = con.stylesheet;
+  argv.lang = con.lang;
+  argv.output = con.output || "./dist";
+}else{
+  console.log("Error: Could not read config.json file");
+  process.exitCode = -1;
+}
+
 if(fs.existsSync(argv.input)){
   if(fs.lstatSync(argv.input).isDirectory()){ //if the input is a directory
     fs.readdirSync(argv.input).forEach(file =>{


### PR DESCRIPTION
This is  fixes #14 
I've added a new feature that supports a config file, so if users want to be able to specify all of their SSG options in a JSON formatted configuration file instead of having to pass them all as command-line arguments every time. 
Specifically, I added yargs option which is -c, --config, and readFileSync function on the textToHTML.js file.
Also, I added the following config file:
./ssg-config.json
```
{
    "input": "./site",
    "output": "./build",
    "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
    "lang": "fr"
}
```
Please let me know if you want any changes or anything I can improve.
Thank you for considering.

